### PR TITLE
[PoC][Dont Merge]Add platform support and a sanity test sample

### DIFF
--- a/ptf/platform_helper/bfn_sai_helper.py
+++ b/ptf/platform_helper/bfn_sai_helper.py
@@ -1,0 +1,9 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class BfnSaiHelper(SaiHelper):
+    platform = 'bfn'
+    
+    def recreate_ports(self):
+        print("BfnSaiHelper::recreate_ports")  

--- a/ptf/platform_helper/brcm_sai_helper.py
+++ b/ptf/platform_helper/brcm_sai_helper.py
@@ -1,0 +1,34 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class BrcmSaiHelper(SaiHelper):
+    platform = 'brcm'
+    
+    def recreate_ports(self):
+        print("BrcmSaiHelperBase::recreate_ports does not support.") 
+
+
+    def check_cpu_port_hdl(self):
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_number_of_queues=True)
+        num_queues = attr['qos_number_of_queues']
+        q_list = sai_thrift_object_list_t(count=num_queues)
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_queue_list=q_list)
+                                             
+        for queue in range(0, num_queues):
+            queue_id = attr['qos_queue_list'].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertTrue(queue == q_attr['index'])
+            #in broadcom platform, the q_attr["port"] is not equals to cpu_port_hdl
+            # cpu_port_hdl is ahead of the cpu_port list
+            self.cpu_port = q_attr["port"]

--- a/ptf/platform_helper/common_sai_helper.py
+++ b/ptf/platform_helper/common_sai_helper.py
@@ -1,0 +1,6 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+class CommonSaiHelper(SaiHelper):
+    platform = 'common'

--- a/ptf/platform_helper/mlnx_sai_helper.py
+++ b/ptf/platform_helper/mlnx_sai_helper.py
@@ -1,0 +1,7 @@
+import sys
+sys.path.append("..")
+from  sai_base_test import *
+
+
+class MlnxSaiHelper(SaiHelper):
+    platform = 'mlnx'

--- a/ptf/sai_base_test.py
+++ b/ptf/sai_base_test.py
@@ -21,11 +21,17 @@ and/or dataplane automatically set up.
 """
 
 import os
+import time
+import socket
+import struct
+from threading import Thread
 
 from collections import OrderedDict
 
+import ptf
 from ptf import config
 from ptf.base_tests import BaseTest
+import ptf.testutils as testutils
 
 from thrift.transport import TSocket
 from thrift.transport import TTransport
@@ -34,10 +40,13 @@ from thrift.protocol import TBinaryProtocol
 from sai_thrift import sai_rpc
 
 from sai_utils import *
+import platform_helper
 
 ROUTER_MAC = '00:77:66:55:44:00'
 THRIFT_PORT = 9092
 
+PLATFORM = os.environ.get('PLATFORM')
+platform_map = {'broadcom':'brcm', 'barefoot':'bfn', 'mellanox':'mlnx'}
 
 class ThriftInterface(BaseTest):
     """
@@ -118,7 +127,6 @@ class ThriftInterfaceDataPlane(ThriftInterface):
     """
     def setUp(self):
         super(ThriftInterfaceDataPlane, self).setUp()
-
         self.dataplane = ptf.dataplane_instance
         if self.dataplane is not None:
             self.dataplane.flush()
@@ -133,6 +141,8 @@ class ThriftInterfaceDataPlane(ThriftInterface):
 
 
 class SaiHelperBase(ThriftInterfaceDataPlane):
+    platform = 'common'
+   
     """
     SAI test helper base class without initial switch ports setup
 
@@ -147,15 +157,112 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.port_list - list of all active port objects
         self.portX objects for all active ports (where X is a port number)
     """
+
+    def get_active_port_list(self):
+        '''
+        Method to get the active port list base on number_of_active_ports
+
+        Sets the following class attributes:
+
+            self.active_ports - number of active ports 
+
+            self.port_list - list of all active port objects
+
+            self.portX objects for all active ports
+        '''
+
+        #Gets self.number_of_ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, number_of_active_ports=True)
+        self.active_ports = attr['number_of_active_ports']
+
+        #Gets self.port_list based on number_of_active_ports
+        attr = sai_thrift_get_switch_attribute(
+            self.client, port_list=sai_thrift_object_list_t(
+                idlist=[], count=self.active_ports))
+        self.assertEqual(self.active_ports, attr['port_list'].count)
+        self.port_list = attr['port_list'].idlist
+
+        #Gets self.portX objects for all active ports
+        for index in range(0, len(self.port_list)):
+            setattr(self, 'port%s' % index, self.port_list[index])
+
+    
+    def turn_up_ports(self):
+        '''
+        Method to turn up the ports.
+        '''
+        retries = 10
+        for port_id in self.port_list:
+            try:
+                sai_thrift_set_port_attribute(
+                    self.client, port_oid=port_id, admin_state=True)
+            except BaseException as e:
+                print("Cannot setup port admin state, error {}".format(e))
+        
+        for num_of_tries in range(retries):
+            all_ports_are_up = True
+            time.sleep(2)
+            for port_id in self.port_list:
+                port_attr = sai_thrift_get_port_attribute(
+                    self.client, port_id, oper_status=True)
+                if port_attr['oper_status'] != SAI_PORT_OPER_STATUS_UP:
+                    all_ports_are_up = False
+                    time.sleep(1)
+                    print("port is down: {}".format(port_attr['oper_status']))
+            if all_ports_are_up:
+                break
+        if not all_ports_are_up:
+            print("Not all the ports are up after {} rounds of retries.".format(retries))
+
+
+
+    def shell(self):
+        def start_shell():
+            sai_thrift_set_switch_attribute(self.client, switch_shell_enable=True)
+        thread = Thread(target = start_shell)
+        thread.start()
+
+    
+    def recreate_ports(self):
+        if 'port_config_ini' in self.test_params:
+            if 'createPorts_has_been_called' not in config:
+                self.createPorts()
+                # check if ports became UP
+                #self.checkPortsUp()
+                config['createPorts_has_been_called'] = 1
+
+    
+    def check_cpu_port_hdl(self):
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_number_of_queues=True)
+        num_queues = attr['qos_number_of_queues']
+        q_list = sai_thrift_object_list_t(count=num_queues)
+        attr = sai_thrift_get_port_attribute(self.client,
+                                             self.cpu_port_hdl,
+                                             qos_queue_list=q_list)
+        for queue in range(0, num_queues):
+            queue_id = attr['qos_queue_list'].idlist[queue]
+            setattr(self, 'cpu_queue%s' % queue, queue_id)
+            q_attr = sai_thrift_get_queue_attribute(
+                self.client,
+                queue_id,
+                port=True,
+                index=True,
+                parent_scheduler_node=True)
+            self.assertTrue(queue == q_attr['index'])
+            self.assertTrue(self.cpu_port_hdl == q_attr["port"])
+
+
     def setUp(self):
         super(SaiHelperBase, self).setUp()
 
         self.getSwitchPorts()
-
         # initialize switch
         self.switch_id = sai_thrift_create_switch(
             self.client, init_switch=True, src_mac_address=ROUTER_MAC)
-        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+        #self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
 
         self.switch_resources = self.saveNumberOfAvaiableResources()
 
@@ -165,12 +272,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.default_vlan_id = attr['default_vlan_id']
         self.assertTrue(self.default_vlan_id != 0)
 
-        if 'port_config_ini' in self.test_params:
-            if 'createPorts_has_been_called' not in config:
-                self.createPorts()
-                config['createPorts_has_been_called'] = 1
-                # check if ports became UP
-                self.checkPortsUp()
+        self.recreate_ports()
 
         # get number of active ports
         attr = sai_thrift_get_switch_attribute(
@@ -193,6 +295,8 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.default_vrf = attr['default_virtual_router_id']
         self.assertTrue(self.default_vrf != 0)
 
+        self.turn_up_ports()
+
         # get default 1Q bridge OID
         attr = sai_thrift_get_switch_attribute(
             self.client, default_1q_bridge_id=True)
@@ -205,25 +309,7 @@ class SaiHelperBase(ThriftInterfaceDataPlane):
         self.assertTrue(self.cpu_port_hdl != 0)
 
         # get cpu port queue handles
-        attr = sai_thrift_get_port_attribute(self.client,
-                                             self.cpu_port_hdl,
-                                             qos_number_of_queues=True)
-        num_queues = attr['qos_number_of_queues']
-        q_list = sai_thrift_object_list_t(count=num_queues)
-        attr = sai_thrift_get_port_attribute(self.client,
-                                             self.cpu_port_hdl,
-                                             qos_queue_list=q_list)
-        for queue in range(0, num_queues):
-            queue_id = attr['qos_queue_list'].idlist[queue]
-            setattr(self, 'cpu_queue%s' % queue, queue_id)
-            q_attr = sai_thrift_get_queue_attribute(
-                self.client,
-                queue_id,
-                port=True,
-                index=True,
-                parent_scheduler_node=True)
-            self.assertTrue(queue == q_attr['index'])
-            self.assertTrue(self.cpu_port_hdl == q_attr['port'])
+        self.check_cpu_port_hdl()
 
     def tearDown(self):
         try:
@@ -939,3 +1025,25 @@ class MinimalPortVlanConfig(SaiHelperBase):
             sai_thrift_remove_bridge_port(self.client, bridge_port)
 
         super(MinimalPortVlanConfig, self).tearDown()
+
+
+def get_platform():
+    pl_low = PLATFORM.lower()
+    pl = 'common'
+    if pl_low in platform_map.keys():
+        pl = platform_map[pl_low]
+    elif pl_low in platform_map.values():
+        pl = pl_low
+    return pl
+
+
+class PlatformSaiHelper(SaiHelper):
+    def __new__(cls, *args, **kwargs):
+        sai_helper_subclass_map = {subclass.platform: subclass for subclass in SaiHelper.__subclasses__()}       
+        pl = get_platform()
+
+        target_base_class = sai_helper_subclass_map[pl]
+        cls.__bases__ = (target_base_class,)
+            
+        instance = target_base_class.__new__(cls, *args, **kwargs)
+        return instance 

--- a/ptf/saisanity.py
+++ b/ptf/saisanity.py
@@ -1,0 +1,339 @@
+
+from __future__ import print_function
+
+from sai_thrift.sai_headers import *
+
+from ptf.testutils import *
+from ptf.dataplane import DataPlane
+from ptf.packet import *
+from ptf.thriftutils import *
+
+from sai_base_test import *
+
+class L2SanityTest(PlatformSaiHelper):
+    def gen_mac(self):
+         #Gets self.portX objects for all active ports
+        for index in range(0, len(self.port_list)):
+            mac = "00"
+            if index < 9 :
+                section = ":" + "0" + str(index+1)
+            else:
+                section= ":" + str(index+1)
+            mac += (section*5)
+            setattr(self, 'mac%s' % index, mac)
+
+    
+    def create_bridge_ports(self):
+        for index in range(0, len(self.port_list)):
+            port_id = getattr(self, 'port%s' % index)
+            port_bp = sai_thrift_create_bridge_port(
+                self.client,
+                bridge_id=self.default_1q_bridge,
+                port_id=port_id,
+                type=SAI_BRIDGE_PORT_TYPE_PORT,
+                admin_state=True)
+            setattr(self, 'port%s_bp' % index, port_bp)
+            self.assertTrue(getattr(self, 'port%s_bp' % index) != 0)
+
+
+    def create_vlan_ports(self, vlanid, vlan_oid):
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            if index%2 == 0:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_UNTAGGED)
+            else:
+                vlan_member = sai_thrift_create_vlan_member(
+                    self.client,
+                    vlan_id=self.vlan_oid,
+                    bridge_port_id=port_bp,
+                    vlan_tagging_mode=SAI_VLAN_TAGGING_MODE_TAGGED)
+
+            setattr(self, 'vlan%s_member%s' % (vlanid, index), vlan_member)
+
+
+    def set_port_vlan(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=vlan_id)
+
+
+    def create_port_fdb(self, vlan_id, vlan_oid, mac_action):
+        for index in range(0, len(self.port_list)):
+            mac=getattr(self, 'mac%s' % index)
+            port_bp = getattr(self, 'port%s_bp' % index)
+            fdb_entry = sai_thrift_fdb_entry_t(
+                switch_id=self.switch_id, mac_address=mac, bv_id=vlan_oid)
+            sai_thrift_create_fdb_entry(
+                self.client,
+                fdb_entry,
+                type=SAI_FDB_ENTRY_TYPE_STATIC,
+                bridge_port_id=port_bp,
+                packet_action=mac_action)
+            setattr(self, 'fdb_entry%s' % index, fdb_entry)
+
+
+    def create_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:                
+                pkt = simple_tcp_packet(eth_src=self.src_mac,
+                                        eth_dst=target_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=101,
+                                        ip_ttl=64)                
+            else:
+                pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        ip_ttl=64)
+            setattr(self, 'pkt%s' % index, pkt)
+
+    def create_exp_pkt(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            target_mac = getattr(self, 'mac%s' % index)
+            if index%2 == 0:                
+                exp_pkt = getattr(self, 'pkt%s' % index)                
+            else:
+                exp_pkt = simple_tcp_packet(eth_dst=target_mac,
+                                        eth_src=self.src_mac,
+                                        ip_dst='172.16.0.1',
+                                        ip_id=102,
+                                        dl_vlan_enable=True,
+                                        vlan_vid=vlan_id,
+                                        ip_ttl=64)
+            setattr(self, 'exp_pkt%s' % index, exp_pkt)
+
+
+    def setUp(self):
+        #Init switch
+        SaiHelperBase.setUp(self)
+
+        self.vlan_id = 10
+        self.gen_mac()
+        self.src_mac=self.mac0
+        mac_action = SAI_PACKET_ACTION_FORWARD
+
+        self.src_port = self.port0
+        self.dst_port = self.port1
+
+        # create bridge ports
+        self.create_bridge_ports()
+
+        # create vlan 10 with ports
+        self.vlan_oid = sai_thrift_create_vlan(self.client, vlan_id=self.vlan_id)
+        self.assertTrue(self.vlan_oid != 0)
+        self.create_vlan_ports(self.vlan_id, self.vlan_oid)
+
+        #set port vlan attribute
+        self.set_port_vlan(self.vlan_id)
+
+        #set fdb
+        self.create_port_fdb(self.vlan_id, self.vlan_oid, mac_action)
+
+        #create send pkt and rcv pkt
+        self.create_pkt(self.vlan_id)
+        self.create_exp_pkt(self.vlan_id)
+
+
+    def runTest(self):
+        try:
+            for index in range(1, len(self.port_list)):
+                target_pkt = getattr(self, 'pkt%s' % index)
+                target_mac = getattr(self, 'mac%s' % index)
+                target_port = getattr(self, 'dev_port%s' % index)
+                exp_pkt = getattr(self, 'exp_pkt%s' % index)
+                
+                send_packet(self, self.dev_port0, target_pkt)
+                verify_packet(self, exp_pkt, index) 
+                #res = verify_any_packet_on_ports_list(self, [exp_pkt], [[i for i in range(0,32)]])
+        finally:
+            pass
+
+    
+    def tearDown(self):
+        #reset port vlan id
+        #?reset to 0 or 1?
+        self.reset_port_vlan(1)
+
+        #remove fdb
+        self.remove_fdb()
+
+        #remove vlan member
+        self.remove_vlan_member(self.vlan_id)        
+
+        #remove bridge port
+        self.remove_bridge_port()
+
+        sai_thrift_remove_vlan(self.client, self.vlan_oid)
+
+    def reset_port_vlan(self, reset_vlan_id):
+        for index in range(0, len(self.port_list)):
+            port_id=getattr(self, 'port%s' % index)
+            sai_thrift_set_port_attribute(self.client, port_id, port_vlan_id=reset_vlan_id)
+
+    def remove_fdb(self):
+        for index in range(0, len(self.port_list)):
+            fdb_entry=getattr(self, 'fdb_entry%s' % index)
+            sai_thrift_remove_fdb_entry(self.client, fdb_entry)
+
+
+    def remove_vlan_member(self, vlan_id):
+        for index in range(0, len(self.port_list)):
+            vlan_member=getattr(self, 'vlan%s_member%s' % (vlan_id, index))
+            sai_thrift_remove_vlan_member(self.client, vlan_member)
+
+    def remove_bridge_port(self):
+        for index in range(0, len(self.port_list)):
+            port_bp = getattr(self, 'port%s_bp' % index)
+            sai_thrift_remove_bridge_port(self.client, port_bp)
+
+
+
+
+###############################################################################
+# Helper functions                                                            #
+# Hack for now, need to be removed or upstreamed                              #
+###############################################################################
+# pylint: disable=dangerous-default-value,too-many-arguments
+def verify_any_packet_on_ports_list(
+        test,
+        pkts=[],
+        ports=[],
+        device_number=0,
+        timeout=2,
+        no_flood=False):
+    """
+    Ports is list of port lists
+    Check that _any_ packet is received atleast once in every sublist in
+    ports belonging to the given device (default device_number is 0).
+
+    Also verifies that the packet is ot received on any other ports for this
+    device, and that no other packets are received on the device
+    (unless --relax is in effect).
+    Args:
+        test (testcase): Test case
+        pkts (packets): list of packets
+        ports (ports): list of ports
+        device_number (int): device under test
+        timeout (int): timeout
+        no_flood (int): do not flood
+    Returns:
+        rcv_idx: list of port indices
+    """
+    rcv_idx = []
+    failures = {}
+    pkt_cnt = 0
+    for port_list in ports:
+        rcv_ports = set()
+        remaining_timeout = timeout
+        port_sub_list_failures = []
+        port_sub_list_poll_success = False
+        if remaining_timeout > 0:
+            port_idx = 0
+            port_list_len = len(port_list)
+            while remaining_timeout > 0 or port_idx > 0:
+                port = port_list[port_idx]
+                port_idx = (port_idx + 1) % port_list_len
+                remaining_timeout = remaining_timeout - 0.1
+                (rcv_device, rcv_port, rcv_pkt, _) = test.dataplane.poll(
+                    port_number=port, timeout=0.1, filters=get_filters())
+                print("port {} received, received port id: {}".format(port, rcv_port))
+                if rcv_device != device_number:
+                    continue
+                for pkt in pkts:
+                    logging.debug("Checking for pkt on device %d, port %d",
+                                  device_number, port)
+                    if ptf.dataplane.match_exp_pkt(pkt, rcv_pkt):
+                        pkt_cnt += 1
+                        rcv_ports.add(port_list.index(rcv_port))
+                        port_sub_list_failures = []
+                        port_sub_list_poll_success = True
+                        break
+                    else:
+                        port_sub_list_failures.append(
+                            (port, DataPlane.PollFailure(pkt, [rcv_pkt], 1)))
+                if port_sub_list_poll_success and no_flood:
+                    break
+        # Either no expected packets received or unexpected packets recieved
+        if not port_sub_list_poll_success or port_sub_list_failures:
+            port_tuple = tuple(port_list)
+            failures.setdefault(port_tuple, [])
+            failures[port_tuple] = failures[port_tuple] + \
+                port_sub_list_failures
+        rcv_idx.append(rcv_ports)
+
+    verify_no_other_packets(test)
+    if failures:
+        def format_per_port_failure(port, failure):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format one port
+            Args:
+              port (int): port
+              failure (str): message
+            """
+            return "On port {}\n{}".format(port, failure.format())
+
+        def format_per_port_failures(fail_list):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format one port all failures
+            Args:
+              fail_list (array): port and failures
+            """
+            return "\n".join([format_per_port_failure(port, failure)
+                              for (port, failure) in fail_list])
+
+        def format_port_list_failures(port_list, fail_list):
+            # pylint: disable=missing-return-doc,missing-return-type-doc
+            """
+            Format all port all failures
+            Args:
+              port_list (array): ports
+              fail_list (array): port and failures
+            """
+            return "None of the exp pkts rx'd for port list {}: \n{}".format(
+                port_list, format_per_port_failures(fail_list))
+        failure_report = "\n".join([
+            format_port_list_failures(port_list, fail_list)
+            for port_list, fail_list in list(failures.items())
+        ])
+        test.fail(
+            "Did not receive expected packets on any of {} for device {}. \n{}"
+            .format(ports, device_number, failure_report))
+
+    test.assertTrue(
+        pkt_cnt >= len(ports),
+        "Did not receive pkt on one of ports %r for device %d" %
+        (ports, device_number))
+    return rcv_idx
+
+
+def set_vlan_data(vlan_id=0, ports=None, untagged=None, large_port=0):
+    """
+    Creates dictionary with vlan data
+
+    Args:
+        vlan_id (int): VLAN ID number
+        ports (list): ports numbers
+        untagged (list): list of untagged ports
+        large_port (int): the largest port in vlan
+
+    Return:
+        dictionary: vlan_data_dict
+    """
+    vlan_data_dict = {
+        "vlan_id": vlan_id,
+        "ports": ports,
+        "untagged": untagged,
+        "large_port": large_port
+    }
+    return vlan_data_dict
+


### PR DESCRIPTION
Add a middle layer (strategy and factory) under the test cases which can
1. no more if-else for platform selecting
1. no more code injection for different platforms, just need to abstract to a method on the differences
1. auto select the platform by the parameters in the test starter (shell, happed in run_p4_tests, not published here)
1. easy-distinct structure for the difference from platforms
1. prepared for future statistic

Add a sanity sample, it can
1. configure across all the ports (base on port's configuration file)
1. simple FDB and VLAN naming according to port's number
1. make a basic check on the status of the devices
1. use as a sample for how to use the new middle layer

testing done:
barefoot and broadcom platforms